### PR TITLE
Initial gitvote config and pr templates (to auto-call a vote on coc changes)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/coc_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/coc_change.md
@@ -1,0 +1,16 @@
+<!--
+Thank you for your Pull Request! This looks to be a PR that affects or changes the Code of Conduct.
+
+As such, this PR will require review from multiple groups, all of whom must vote before the PR can be accepted.
+
+Please leave the various /vote commands for each group in place. Thanks for your contribution!
+-->
+
+## Description of change
+...
+
+## Call for vote
+/vote-reviewers
+/vote-toc
+/vote-gb
+/vote-elected

--- a/.github/PULL_REQUEST_TEMPLATE/other.md
+++ b/.github/PULL_REQUEST_TEMPLATE/other.md
@@ -1,0 +1,3 @@
+<!--
+Thank you for your Pull Request! This looks to be an administrative-based PR and won't require a full vote of all reviewers and owners.
+-->

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,0 +1,52 @@
+# Example file: https://github.com/cncf/gitvote/blob/main/docs/config/.gitvote.yml
+default:
+  duration: 4w
+  pass_threshold: 66
+  allowed_voters:
+    users:
+      - jeefy
+      - amye
+      - caniszczyk
+
+gb: # Governing Board Representatives
+  duration: 4w
+  pass_threshold: 50
+  allowed_voters:
+    users:
+      - arun-gupta # Arun Gupta
+      - alena1108  # Alena Prokharchyk
+toc: # TOC Representatives
+  duration: 4w
+  pass_threshold: 50
+  allowed_voters:
+    users:
+      - dims       # Davanum Srinivas
+      - mattfarina # Matt Farina
+
+elected: # Elected Representatives
+  duration: 4w
+  pass_threshold: 50
+  allowed_voters:
+    users:
+      - cblecker # Christoph Blecker
+      - anvega   # Andres Vega
+
+reviewers: 
+  duration: 4w
+  pass_threshold: 20
+  allowed_voters:
+    users:
+      - alolita       # Alolita Sharma
+      - amye          # Amye Scavarda Perrin
+      - lumjjb        # Brandon Lum
+      - carlagaggini  # Carla Gaggini
+      - carolynvs     # Carolyn Van Slyck
+      - caniszczyk    # Chris Aniszczyk
+      - endocrimes    # Danielle Lancashire
+      - dzolotusky    # Dave Zolotusky
+      - thefoxatwork  # Emily Fox
+      - erinboyd      # Erin Boyd
+      - jeefy         # Jeffrey Sica
+      - joannalee333  # Joanna Lee
+      - raravena80    # Ricardo Aravena
+      - tashimi       # Tasha Drew


### PR DESCRIPTION
I've populated a [GitVote](https://github.com/cncf/gitvote) config based on the policy/people in the Readme. The one thing that wasn't explicitly stated was how long a vote should be held for. I defaulted that to `4w`. 

This can easily be changed, or we can handle the (hopefully limited number of) PRs that stay open longer by calling another vote.

Speaking of, this also creates PR templates. :tada: 

Signed-off-by: Jeffrey Sica <jeef111x@gmail.com>